### PR TITLE
Handle colons in passwords

### DIFF
--- a/flask_basicauth.py
+++ b/flask_basicauth.py
@@ -80,7 +80,7 @@ class BasicAuth(object):
         if 'Authorization' in request.headers:
             auth = request.headers['Authorization'].split()
             if len(auth) == 2 and auth[0].lower() == 'basic':
-                username, password = base64.decodestring(auth[1]).split(':')
+                username, password = base64.decodestring(auth[1]).split(':', 1)
                 if self.check_credentials(username, password):
                     return True
         return False

--- a/test_basicauth.py
+++ b/test_basicauth.py
@@ -91,6 +91,13 @@ class BasicAuthTestCase(unittest.TestCase):
             headers={'Authorization': 'Basic ' + auth})
         self.assertEqual(response.status_code, 200)
 
+    def test_responds_with_200_with_correct_credentials_containing_colon(self):
+        self.app.config['BASIC_AUTH_PASSWORD'] = 'matrix:'
+        auth = base64.encodestring("john:matrix:").strip('\r\n')
+        response = self.client.get('/protected',
+            headers={'Authorization': 'Basic ' + auth})
+        self.assertEqual(response.status_code, 200)
+
     def test_runs_decorated_view_after_authentication(self):
         auth = base64.encodestring("john:matrix").strip('\r\n')
         response = self.client.get('/protected',


### PR DESCRIPTION
Fixes an issue where attempts to authenticate passwords containing
one or more colons failed with an HTTP 500 "too many values to
unpack".
