### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ authentication`_.
 Links
 -----
 
-- `Documentation <http://flask-basicauth.readthedocs.org/>`_
+- `Documentation <https://flask-basicauth.readthedocs.io/>`_
 - `Issue Tracker <http://github.com/jpvanhal/flask-basicauth/issues>`_
 - `Code <http://github.com/jpvanhal/flask-basicauth/>`_
 - `Development Version


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.