### PR TITLE
correct deprecated extension import in readme

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ Usage
 Usage of Flask-BasicAuth is simple::
 
     from flask import Flask, render_template
-    from flask.ext.basicauth import BasicAuth
+    from flask_basicauth import BasicAuth
 
     app = Flask(__name__)
 


### PR DESCRIPTION
Ok.. fixed the deprecated extension import call in the demo code of the docs. This fixes issue #8. 

Sorry for any confusion - as you might have been able to tell, this was my first attempt to contribute to OSS. Thanks! 
