### PR TITLE
flask_basicauth.py: add BASIC_AUTH_ALLOW_OPTIONS override flag

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,12 @@ just set ``BASIC_AUTH_FORCE`` configuration variable to `True`::
 You might find this useful, for example, if you would like to protect your
 staging server from uninvited guests.
 
+If you need Flask-BasicAuth to be compatible with
+`Flask-CORS <https://flask-cors.corydolphin.com/en/latest/>`_, just set
+``BASIC_AUTH_ALLOW_OPTIONS`` to `True`::
+
+    app.config['BASIC_AUTH_ALLOW_OPTIONS'] = True
+
 .. warning::
 
    Please make sure that you use SSL/TLS (HTTPS) to encrypt the connection
@@ -64,6 +70,12 @@ A list of configuration keys currently understood by the extension:
 ``BASIC_AUTH_FORCE``
     If set to `True`, makes the whole site require HTTP basic access
     authentication.
+
+    Defaults to `False`.
+
+``BASIC_AUTH_ALLOW_OPTIONS``
+    If set to `True`, allows the ``OPTIONS`` method on the whole site with
+    HTTP basic access authentication, for compatibility with Flask-CORS.
 
     Defaults to `False`.
 

--- a/flask_basicauth.py
+++ b/flask_basicauth.py
@@ -42,6 +42,7 @@ class BasicAuth(object):
         """
         app.config.setdefault('BASIC_AUTH_FORCE', False)
         app.config.setdefault('BASIC_AUTH_REALM', '')
+        app.config.setdefault('BASIC_AUTH_ALLOW_OPTIONS', False)
 
         @app.before_request
         def require_basic_auth():
@@ -76,8 +77,9 @@ class BasicAuth(object):
         """
         auth = request.authorization
         return (
-            auth and auth.type == 'basic' and
-            self.check_credentials(auth.username, auth.password)
+            (current_app.config['BASIC_AUTH_ALLOW_OPTIONS'] and request.method == 'OPTIONS') or
+            (auth and auth.type == 'basic' and
+            self.check_credentials(auth.username, auth.password))
         )
 
     def challenge(self):

--- a/test_basicauth.py
+++ b/test_basicauth.py
@@ -2,7 +2,7 @@ import base64
 import unittest
 
 from flask import Flask
-from flask.ext.basicauth import BasicAuth
+from flask_basicauth import BasicAuth
 
 
 class BasicAuthTestCase(unittest.TestCase):
@@ -38,6 +38,7 @@ class BasicAuthTestCase(unittest.TestCase):
     def test_sets_default_values_for_configuration(self):
         self.assertEqual(self.app.config['BASIC_AUTH_REALM'], '')
         self.assertEqual(self.app.config['BASIC_AUTH_FORCE'], False)
+        self.assertEqual(self.app.config['BASIC_AUTH_ALLOW_OPTIONS'], False)
 
     def test_views_without_basic_auth_decorator_respond_with_200(self):
         response = self.client.get('/')
@@ -47,6 +48,11 @@ class BasicAuthTestCase(unittest.TestCase):
         self.app.config['BASIC_AUTH_FORCE'] = True
         response = self.client.get('/')
         self.assertEqual(response.status_code, 401)
+
+    def test_ignores_authentication_for_options_when_allowed(self):
+        self.app.config['BASIC_AUTH_ALLOW_OPTIONS'] = True
+        response = self.client.options('/')
+        self.assertEqual(response.status_code, 200)
 
     def test_responds_with_401_without_authorization(self):
         response = self.client.get('/protected')


### PR DESCRIPTION
CORS requires pre-flight `OPTIONS` method requests to work without the `Authorization` header from the browser.

Otherwise, the browser will raise CORS errors on calls to any endpoints protected with basic auth, and the requests will not work properly. Here is an example error message from Chrome: `Failed to load https://host:port/api_url: Response for preflight has invalid HTTP status code 401`.

With the `BASIC_AUTH_ALLOW_OPTIONS` config option enabled, the `OPTIONS` requests are allowed, and Flask-CORS can send back the right response for the browser, so that the endpoints will work with CORS enabled.