### PR TITLE
Allow hashed passwords

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,6 +80,9 @@ A list of configuration keys currently understood by the extension:
     You can override :meth:`BasicAuth.check_credentials <flask.ext.basicauth.BasicAuth.check_credentials>`,
     if you need a different authentication logic for your application.
 
+``BASIC_AUTH_PASSWORD_HASH`` (and optional ``BASIC_AUTH_PASSWORD_HASH_SALT``, ``BASIC_AUTH_PASSWORD_HASH_ALGORITHM``, ``BASIC_AUTH_PASSWORD_HASH_ROUNDS``)
+    A PBKDF2-based hash of the password.
+    You can optionally set a salt, algorithm and number of rounds. If not, these default to no salt, SHA-512 and 100,000 rounds.
 
 API reference
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ A list of configuration keys currently understood by the extension:
 ``BASIC_AUTH_PASSWORD_HASH`` (and optional ``BASIC_AUTH_PASSWORD_HASH_SALT``, ``BASIC_AUTH_PASSWORD_HASH_ALGORITHM``, ``BASIC_AUTH_PASSWORD_HASH_ROUNDS``)
     A PBKDF2-based hash of the password.
     You can optionally set a salt, algorithm and number of rounds. If not, these default to no salt, SHA-512 and 100,000 rounds.
+    To generate a hash, please use the ``generate_password_hash.py`` script in the base of the repository.
 
 API reference
 -------------

--- a/flask_basicauth.py
+++ b/flask_basicauth.py
@@ -63,9 +63,15 @@ class BasicAuth(object):
         :returns: `True` if the username and password combination was correct,
             and `False` otherwise.
         """
+        return self.check_username(username) and self.check_password_plain(password)
+
+    def check_username(self, username):
         correct_username = current_app.config['BASIC_AUTH_USERNAME']
+        return username == correct_username
+
+    def check_password_plain(self, password):
         correct_password = current_app.config['BASIC_AUTH_PASSWORD']
-        return username == correct_username and password == correct_password
+        return password == correct_password
 
     def authenticate(self):
         """

--- a/generate_password_hash.py
+++ b/generate_password_hash.py
@@ -1,0 +1,19 @@
+import binascii
+import hashlib
+import os
+
+from sys import version_info
+if version_info.major == 2:
+  input = raw_input
+
+algorithm = input('Algorithm (sha512): ') or 'sha512'
+salt = input('Salt: ') or ''
+rounds = input('Rounds (100000): ') or 100000
+
+os.system('stty -echo')
+password = input('Password: ')
+os.system('stty echo')
+print("")
+
+hash = hashlib.pbkdf2_hmac(algorithm, password.encode('utf-8'), salt.encode('ascii'), rounds)
+print(binascii.hexlify(hash).decode('ascii'))

--- a/test_basicauth.py
+++ b/test_basicauth.py
@@ -2,7 +2,7 @@ import base64
 import unittest
 
 from flask import Flask
-from flask.ext.basicauth import BasicAuth
+from flask_basicauth import BasicAuth
 
 
 class BasicAuthTestCase(unittest.TestCase):


### PR DESCRIPTION
I'd like to use simple basic auth for a service, but without storing the plain-text password on the host.

This allows setting a PBKDF2-derived hash value in place of the password, with some optional configuration parameters to choose the algorithm, salt and number of rounds.

I believe this also avoids the variable-time password comparison described in #3 / #21, when configured to use a hashed password.